### PR TITLE
PXC-3038: Resolve valgrind symbols within wsrep/galera

### DIFF
--- a/wsrep_loader.c
+++ b/wsrep_loader.c
@@ -225,8 +225,10 @@ void wsrep_unload(wsrep_t *hptr)
     } else {
         if (hptr->free)
             hptr->free(hptr);
+#ifndef USE_VALGRIND
         if (hptr->dlh)
             dlclose(hptr->dlh);
+#endif
         free(hptr);
     }
 }


### PR DESCRIPTION
Issue: some symbols are not resolved, becasue valgrind can't resolve
symbols from DLL/SO objects that were unloaded previously.

Solution: Do not unload wsrep library when using valgrind.