### PR TITLE
PXC-4799: PXC member used for backups fails with Inconsistency when p…

### DIFF
--- a/wsrep_api.h
+++ b/wsrep_api.h
@@ -1481,6 +1481,15 @@ struct wsrep_st {
     wsrep_seqno_t (*pause) (wsrep_t* wsrep);
 
   /*!
+   * @brief Tries to pause writeset applying/committing without blocking.
+   *
+   * @return global sequence number of the paused state,
+   *         -EAGAIN if pausing would block,
+   *         or other negative error code.
+   */
+   wsrep_seqno_t (*try_pause) (wsrep_t* wsrep);
+
+  /*!
    * @brief Resumes writeset applying/committing.
    */
     wsrep_status_t (*resume) (wsrep_t* wsrep);

--- a/wsrep_dummy.c
+++ b/wsrep_dummy.c
@@ -365,6 +365,12 @@ static wsrep_seqno_t dummy_pause (wsrep_t* w)
     return -ENOSYS;
 }
 
+static wsrep_seqno_t dummy_try_pause (wsrep_t* w)
+{
+    WSREP_DBUG_ENTER(w);
+    return -ENOSYS;
+}
+
 static wsrep_status_t dummy_resume (wsrep_t* w)
 {
     WSREP_DBUG_ENTER(w);
@@ -446,6 +452,7 @@ static wsrep_t dummy_iface = {
     &dummy_fetch_pfs_info,
     &dummy_rotate_gcache_key,
     &dummy_pause,
+    &dummy_try_pause,
     &dummy_resume,
     &dummy_desync,
     &dummy_resync,


### PR DESCRIPTION
…ending DDL clashes with FTRWL

Problem:
LOCK..BACKUP with FTWRL and DDL on remote node caused inconsistent state.

Description:
FTWRL caused MDL lock and waited for DDL to finish in the PXC. FTWRL specifically waits in desync_and_pause->pause statement waiting for concurrent pause statement to finish.

Resolution:
DDLs cannot be executed in parallel with FTWRL in local node it will fail. So on local node ER_CANT_UPDATE_WITH_READLOCK is seen post FTWRL FLUSH TABLES WITH READ LOCK;
--error ER_CANT_UPDATE_WITH_READLOCK
CREATE TABLE t1 (id INT PRIMARY KEY, a INT);
However in PXC remote node not aware of FTWRL on another node accepts the DDL and sends across the cluster opening a pandora of unknown conditions. So, we prevent FLUSH TABLES WITH READ LOCK when the session already holds explicit table locks.
We also check that pause will block; with ongoing TO isolation, MDL locks are likely to conflict with FTWRL, so it is best to fail FTWRL. By rejecting FLUSH TABLES WITH READ LOCK in this situation, we avoid the deadlock-like condition and allow the remote DDL to proceed to avoid situations like below:
NODE-2
LOCK INSTANCE FOR BACKUP;
NODE-1
CREATE TABLE t_synch1 (id INT PRIMARY KEY, a INT); NODE-2
FLUSH TABLES WITH READ LOCK;
NODE-2
UNLOCK TABLE;
UNLOCK INSTANCE;
NOTE: Even with this safeguard, if the DDL waiting for MDL exceeds lock_wait_timeout, the DDL will fail while waiting for the maitenance operations to finish. FLUSH or DDL will not block so the session can execute UNLOCK for the DDL to complete.
This behavior is specific to PXC. In standalone PS/PXC servers, such conflicting operations fail naturally, but in multi-node PXC deployments, DDL may arrive from another node, making this protection necessary.